### PR TITLE
Update select_dialog.dart

### DIFF
--- a/lib/select_dialog.dart
+++ b/lib/select_dialog.dart
@@ -108,7 +108,7 @@ class _SelectDialogState<T> extends State<SelectDialog<T>> {
                   else if (!snapshot.hasData)
                     return Center(child: CircularProgressIndicator());
                   else if (snapshot.data.isEmpty)
-                    return Center(child: Text("No data found"));
+                    return Center(child: Text("Nenhum Item Encontrado."));
                   return ListView.builder(
                     itemCount: snapshot.data.length,
                     itemBuilder: (context, index) {


### PR DESCRIPTION
Padronizado o texto para português,  o campo de texto já usa a palavra fixa "Procurar" e quando não encontra itens tem a mensagem em inglês, o que dificulta a utilização em qualquer lingua, por hora feito o fix pra poder usar ao menos em portugues, o ideal é  usar o localization, mas pode ser feito em um segundo momento.