### PR TITLE
fix for flutter 3.13+

### DIFF
--- a/lib/select_dialog.dart
+++ b/lib/select_dialog.dart
@@ -215,7 +215,7 @@ class _SelectDialogState<T> extends State<SelectDialog<T>> {
                 }
                 return Scrollbar(
                   controller: bloc.scrollController,
-                  isAlwaysShown: widget.alwaysShowScrollBar,
+                  thumbVisibility: widget.alwaysShowScrollBar,
                   child: ListView.builder(
                     controller: bloc.scrollController,
                     itemCount: snapshot.data!.length,


### PR DESCRIPTION
on flutter 3.13+ `isAlwaysShown` was removed as Deprecated and replaced with `thumbVisibility` - **breaking change**