### PR TITLE
Fixes #40: replace isAlwaysShown with thumbVisibility

### DIFF
--- a/lib/select_dialog.dart
+++ b/lib/select_dialog.dart
@@ -215,7 +215,7 @@ class _SelectDialogState<T> extends State<SelectDialog<T>> {
                 }
                 return Scrollbar(
                   controller: bloc.scrollController,
-                  isAlwaysShown: widget.alwaysShowScrollBar,
+                  thumbVisibility: widget.alwaysShowScrollBar,
                   child: ListView.builder(
                     controller: bloc.scrollController,
                     itemCount: snapshot.data!.length,


### PR DESCRIPTION
`isAlwaysShown` is deprecated:  https://api.flutter.dev/flutter/material/Scrollbar/isAlwaysShown.html

Are there any backward compatibility considerations that need to be worked on?